### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "TrigPi",
+    "license" : "MIT",
     "version" : "1.3.0",
     "description" : "accurate computation of sin(π*$x) and cos(π*$x)",
     "author" : "Lucien Grondin",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license